### PR TITLE
addon enable error fix working with blender 3.5

### DIFF
--- a/io_bcry_exporter/export.py
+++ b/io_bcry_exporter/export.py
@@ -32,7 +32,7 @@ import time
 import xml.dom.minidom
 from collections import OrderedDict
 from datetime import datetime
-from time import clock
+from time import perf_counter as clock
 from xml.dom.minidom import Document, Element, parse, parseString
 
 import bmesh


### PR DESCRIPTION
Based on the error, now works with latest blender version 3.5.
https://github.com/LeonidasWhite/BCRYExporter/issues/6